### PR TITLE
Fix duplicate logs

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -43,3 +43,7 @@ console_handler.setFormatter(formatter)
 # Add handlers to logger
 logger.addHandler(file_handler)
 logger.addHandler(console_handler)
+# Prevent log messages from being propagated to the root logger, which already
+# has handlers configured via `basicConfig`. Without this, each log entry would
+# appear twice (once from this logger and once from the root logger).
+logger.propagate = False


### PR DESCRIPTION
## Summary
- prevent logger propagation to avoid duplicate logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68449f6196688329be81852b1bbeee05